### PR TITLE
added cli config file for js language

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,0 +1,3 @@
+{
+    "language":"js"
+}


### PR DESCRIPTION
By default after cloning this repo using the cli to generate schematics produces TypeScript files. Adding the nest-cli.json file with the language set to "js" will tell the cli to generate JavaScript files instead.